### PR TITLE
fix property get problem

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -131,7 +131,7 @@ class Apollo {
     if (!this.releaseKeys[namespace]) {
       await sleep(5000);
     }
-    return _.get(this.localCachedConfigs, `${namespace}.${key}`, "");
+    return _.get(this.localCachedConfigs, [ namespace, key ], "");
   }
 
   /**


### PR DESCRIPTION
`_.get(object, pathString)` will not return expected value if the pathString contains `.`, for example, `fetchConfig` will not work if the config key is something like this: `logging.level`. 
Changed to `_.get(obj, [ pathString, pathString ])`